### PR TITLE
FIX use column name parametre instead of 'column'

### DIFF
--- a/ExperimentsDVC/src/features/feature_engineering.py
+++ b/ExperimentsDVC/src/features/feature_engineering.py
@@ -47,4 +47,4 @@ def delta_time(data, column):
 
 def drop_column(data, column):
     """Drop a column from the dataset"""
-    data.drop(['column'], axis=1)
+    data.drop([column], axis=1)


### PR DESCRIPTION
The function drop_column was not using the column parameter.